### PR TITLE
Allow using 1.12.x patch versions of dub

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -13,7 +13,7 @@
 		"dls:bootstrap": "*",
 		"dls:i18n": "*",
 		"dls:protocol": "*",
-		"dub": "1.12.0",
+		"dub": "~>1.12.0",
 		"dcd": "0.9.13",
 		"dscanner": "0.5.11",
 		"dfmt": "0.8.3"

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -5,7 +5,6 @@
 		"dfmt": "0.8.3",
 		"dscanner": "0.5.11",
 		"dsymbol": "0.4.8",
-		"dub": "1.12.0",
 		"emsi_containers": "0.8.0-alpha.11",
 		"inifiled": "1.3.1",
 		"libddoc": "0.4.0",


### PR DESCRIPTION
The `~>1.12.0` syntax (which is short for `>=1.12.0 <1.13.0`) should be preferred as it allows bug fixes published as patch versions from dub to propagate to dls, while preventing breaking changes (if we assume that such may happen in a minor version). For this to work, the exact dub version should be removed from `dub.selections.json`, as this file overrides any flexibility in `dub.json` / `dub.sdl`.

Context:
All pull requests against core D repos (dmd, druntime, phobos and dub) in addition to their own testing, are also tested on the [BuildKite](https://forum.dlang.org/post/vytpearrfgxqfqugtaow@forum.dlang.org) project tester (e.g. https://github.com/dlang/ci).
It builds and tests popular projects such as yours with the combination of the master branches of all D repos and the branch of the PR. For example, a PR against dmd would combine: dmd/pull9017 + druntime/master + phobos/master + dub/master, where as a PR against druntime would combine: dmd/master + druntime/pull2376 + phobos/master + dub/master.

A DMD bug fix https://github.com/dlang/dmd/pull/9017 is blocked a by wrong cast in dub's code base. The wrong cast was removed in https://github.com/dlang/dub/pull/1600, however your project is still failing on BuildKite for https://github.com/dlang/dmd/pull/9017, because due to the way `dub.json` and `dub.selections.json` were configured, only dub `1.12.0` can be used.

With this pull request is accepted, if we publish the fix in a dub patch release (e.g. `1.12.1`), when your project is build on BuildKite it will automatically use that version, instead of `1.12.0`. This is necessary for https://github.com/dlang/dmd/pull/9017 to succeed on BuildKite.

To ease maintenance in the future, prefer using the version specification format which allows a range of patch versions (e.g. `~>1.12.0`, `~>1.13.0`, and so on) and don't commit to git changes to `dub.selections.json` that add a fixed version of dub.

Of course, `dub.selections.json` has its place - locking dependency versions is a good idea for applications that don't trust their dependencies w.r.t breaking changes, but given that no PRs against dub will be accepted if they break your project, I think it's reasonable to trust the dub release process in this case.