### PR TITLE
Reload dscanner config when dls config is updated.

### DIFF
--- a/source/dls/tools/analysis_tool.d
+++ b/source/dls/tools/analysis_tool.d
@@ -105,6 +105,7 @@ class AnalysisTool : Tool
                 _instance.scanAllWorkspaces();
             }
         });
+        _instance.addConfigHook("configFile", &_instance.updateAnalysisConfig);
     }
 
     static void shutdown()


### PR DESCRIPTION
Simple fix for issue #41 
May be too simple. It might be good to check if the new value is different from the old value, but I wasn't how to do that, as it doesn't seem to store the old value as-is.