### PR TITLE
#44 Improve startup time for large workspaces.

### DIFF
--- a/source/dls/protocol/jsonrpc.d
+++ b/source/dls/protocol/jsonrpc.d
@@ -176,10 +176,12 @@ private void send(T : Message)(T m)
 
     synchronized
     {
-        foreach (chunk; ["Content-Length: ", text(messageString.length), eol, eol, messageString])
-        {
-            communicator.write(chunk);
-        }
+        communicator.write(
+            "Content-Length: ".toUTF8()
+            ~ text(messageString.length).toUTF8()
+            ~ eol.toUTF8()
+            ~ eol.toUTF8()
+            ~ messageString.toUTF8());
 
         communicator.flush();
     }


### PR DESCRIPTION
The logging was the slowest part, opening and closing a file constantly 7000 times is slow. Not sure how useful it is for you, but I just removed the logging for now with some other changes. It only takes about a second or two to startup now. Could probably still be improved a bit, but it is a lot faster now.